### PR TITLE
Fixed messy text and file_Open() issue

### DIFF
--- a/SimpleINI.inc
+++ b/SimpleINI.inc
@@ -139,7 +139,7 @@ stock file_Open(filename[])
 		if(delim != -1)
 		{
 			__strcpy(ini_KeyData[i], ini_Temp, delim + 1);
-			__strcpy(ini_ValData[i], ini_Temp[delim + 1], MAX_VAL_LENGTH);
+			__strcpy(ini_ValData[i], ini_Temp[delim + 2], MAX_VAL_LENGTH);
 
 			if(ini_KeyData[i][delim - 1] == ' ')
 				strdel(ini_KeyData[i], delim - 1, delim);
@@ -196,7 +196,7 @@ stock file_Save(filename[])
 		}
 		else
 		{
-			format(ini_Temp, MAX_RECORD_LENGTH, "%s = %s\n", ini_KeyData[i], ini_ValData[i]);
+			format(ini_Temp, MAX_RECORD_LENGTH, "%s = %s\r\n", ini_KeyData[i], ini_ValData[i]);
 		}
 
 		fwrite(ini_CurrentFile, ini_Temp);


### PR DESCRIPTION
Added line break on windows as well, so it is easier to read the text
with Notepad, if you don't have Notepad++.

Fixed file_Open(), which added +1 empty space whenever you opened a
file. An empty space gets generated after the "=" symbol under
file_Save(): "%s = %s\r\n", which is a character as well. That why I had
to increase the ini_Temp's index by one.
